### PR TITLE
Add gh links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Suggests:
     ggplot2,
     ggiraph,
     testthat (>= 3.0.0)
-URL: https://michalovadek.github.io/eurlex/
+URL: https://michalovadek.github.io/eurlex/, https://github.com/michalovadek/eurlex
+BugReports: https://github.com/michalovadek/eurlex/issues
 RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr


### PR DESCRIPTION
for discoverability and linking.  https://blog.r-hub.io/2019/12/10/urls/

For auto deployment of the website, you may want to run `usethis::use_pkgdown_github_pages()` to avoid updating docs manually.

You may consider also adding the website link in the about section on the gh repo.
![image](https://github.com/michalovadek/eurlex/assets/52606734/1073b2d8-1d3e-4608-ba6f-01461e28b261)

Cheers