### PR TITLE
fix: add missing closing parenthesis in national_impl FILTER clause

### DIFF
--- a/R/elx_make_query.R
+++ b/R/elx_make_query.R
@@ -385,7 +385,7 @@ elx_make_query <- function(resource_type = c("any","directive","regulation","dec
   }
 
   if (resource_type == "national_impl"){
-    query <- paste(query, "FILTER(?type=<http://publications.europa.eu/resource/authority/resource-type/MEAS_NATION_IMPL>", sep = " ")
+    query <- paste(query, "FILTER(?type=<http://publications.europa.eu/resource/authority/resource-type/MEAS_NATION_IMPL>)", sep = " ")
   }
 
   if (nchar(manual_type) > 1 & resource_type == "manual"){


### PR DESCRIPTION
## Problem

`elx_make_query(resource_type = "national_impl")` generates an invalid 
SPARQL query due to a missing closing parenthesis `)` in the FILTER clause.

**Before (broken):**
FILTER(?type=<http://publications.europa.eu/resource/authority/resource-type/MEAS_NATION_IMPL>

**After (fixed):**
FILTER(?type=<http://publications.europa.eu/resource/authority/resource-type/MEAS_NATION_IMPL>)

## Discovery

Found through real-world use of the package. All other resource types 
(directive, regulation, decision, etc.) close the parenthesis correctly — 
national_impl was the only exception.