### PR TITLE
test: add unit tests for national_impl query validity

### DIFF
--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -7,3 +7,28 @@ testthat::test_that("queries can be made", {
   testthat::expect_gt(nchar(q), 800)
   
 })
+
+
+testthat::test_that("national_impl query has balanced parentheses", {
+  
+  testthat::skip_on_cran()
+  
+  q <- eurlex::elx_make_query("national_impl")
+  
+  n_open <- lengths(regmatches(q, gregexpr("\\(", q)))
+  n_close <- lengths(regmatches(q, gregexpr("\\)", q)))
+  
+  testthat::expect_equal(n_open, n_close)
+  
+})
+
+testthat::test_that("national_impl query is well-formed", {
+  
+  testthat::skip_on_cran()
+  
+  q <- eurlex::elx_make_query("national_impl")
+  
+  testthat::expect_gt(nchar(q), 800)
+  testthat::expect_true(grepl("MEAS_NATION_IMPL", q))
+  
+})


### PR DESCRIPTION
## Context

Following up on the earlier fix for the missing closing parenthesis 
in the `national_impl` FILTER clause (merged), this adds regression 
tests to catch similar issues in the future.

## Changes

- Added a test verifying that parentheses in the `national_impl` 
  query are balanced (would have caught the original bug)
- Added a test verifying the query contains the expected 
  `MEAS_NATION_IMPL` resource type and meets minimum length, 
  consistent with the existing `directive` test

## Testing

All 5 tests pass locally (`devtools::test()`).