### PR TITLE
Use GROUP_CONCAT for include_author to avoid duplicate document rows (issue #26, point 5)

### DIFF
--- a/R/elx_make_query.R
+++ b/R/elx_make_query.R
@@ -9,6 +9,13 @@
 #' requires `?date` to be a well-formed `xsd:date`. Any document whose date 
 #' does not resolve to a valid `xsd:date` would be silently excluded from 
 #' the filtered results, without a warning or error.
+#' 
+#' When `include_author` is `TRUE`, the query uses `GROUP_CONCAT` to combine 
+#' multiple authors for the same document into a single pipe-separated 
+#' (`|`) string in the `author` column, rather than returning one row per 
+#' author. This avoids duplicate rows for documents with multiple authors, 
+#' but means the query switches from `SELECT DISTINCT` to `SELECT ... GROUP BY` 
+#' internally when `include_author` is used.
 #'
 #' @param resource_type Type of resource to be retrieved via SPARQL query
 #' @param manual_type Define manually the type of resource to be retrieved
@@ -104,161 +111,147 @@ elx_make_query <- function(resource_type = c("any","directive","regulation","dec
     stop("'date_to' must be in YYYY-MM-DD format.", call. = TRUE)
   }
 
-  query <- "PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
+  select_stmt <- if (include_author == TRUE) "select" else "select distinct"
+  
+  query <- paste0("PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
   PREFIX annot: <http://publications.europa.eu/ontology/annotation#>
   PREFIX skos:<http://www.w3.org/2004/02/skos/core#>
   PREFIX dc:<http://purl.org/dc/elements/1.1/>
   PREFIX xsd:<http://www.w3.org/2001/XMLSchema#>
   PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
   PREFIX owl:<http://www.w3.org/2002/07/owl#>
-  select distinct ?work ?type"
+  ", select_stmt, " ?work ?type")
+  
+  group_vars <- c("?work", "?type")
+  
 
   if (include_celex == TRUE){
-
     query <- paste(query, "?celex", sep = " ")
-
+    group_vars <- c(group_vars, "?celex")
   }
-
+  
   if (include_date == TRUE || !is.null(date_from) || !is.null(date_to)){
     query <- paste(query, "?date", sep = " ")
+    group_vars <- c(group_vars, "?date")
   }
-
+  
   if (include_date_force == TRUE){
-
     query <- paste(query, "?dateforce", sep = " ")
-
+    group_vars <- c(group_vars, "?dateforce")
   }
-
+  
   if (include_date_endvalid == TRUE){
-
     query <- paste(query, "?dateendvalid", sep = " ")
-
+    group_vars <- c(group_vars, "?dateendvalid")
   }
-
+  
   if (include_date_transpos == TRUE){
-
     query <- paste(query, "?datetranspos", sep = " ")
-
+    group_vars <- c(group_vars, "?datetranspos")
   }
-
+  
   if (include_date_lodged == TRUE){
-
     query <- paste(query, "?datelodged", sep = " ")
-
+    group_vars <- c(group_vars, "?datelodged")
   }
-
+  
   if (include_lbs == TRUE){
-
+    
     if (resource_type %in% c("caselaw")){
       stop("Legal basis variable incompatible with requested resource type", call. = TRUE)
     }
-
+    
     query <- paste(query, "?lbs ?lbcelex ?lbsuffix", sep = " ")
-
+    group_vars <- c(group_vars, "?lbs", "?lbcelex", "?lbsuffix")
   }
-
+  
   if (include_force == TRUE){
-
+    
     if (resource_type %in% c("caselaw")){
       stop("Force variable incompatible with requested resource type", call. = TRUE)
     }
-
+    
     query <- paste(query, "?force", sep = " ")
-
+    group_vars <- c(group_vars, "?force")
   }
-
+  
   if (include_eurovoc == TRUE){
-
     query <- paste(query, "?eurovoc", sep = " ")
-
+    group_vars <- c(group_vars, "?eurovoc")
   }
-
+  
   if (include_court_procedure == TRUE){
-
     query <- paste(query, "?courtprocedure", sep = " ")
-
+    group_vars <- c(group_vars, "?courtprocedure")
   }
-
+  
   if (include_ecli == TRUE){
-
     query <- paste(query, "?ecli", sep = " ")
-
+    group_vars <- c(group_vars, "?ecli")
   }
-
+  
   if (include_author == TRUE){
-
-    query <- paste(query, "?author", sep = " ")
-
+    query <- paste(query, '(group_concat(distinct ?author;separator="|") as ?author)', sep = " ")
   }
   
   if (include_title == TRUE){
     query <- paste(query, "?title", sep = " ")
+    group_vars <- c(group_vars, "?title")
   }
   
   if (include_citations == TRUE){
-    
     query <- paste(query, "?citationcelex", sep = " ")
-    
+    group_vars <- c(group_vars, "?citationcelex")
   }
-
+  
   if (include_citations_detailed == TRUE){
-
     query <- paste(query, "?citationcelex ?citationdetailcit ?citationdetail", sep = " ")
-
+    group_vars <- c(group_vars, "?citationcelex", "?citationdetailcit", "?citationdetail")
   }
-
+  
   if (include_directory == TRUE | include_directory_code == TRUE){
-
     query <- paste(query, "?directory", sep = " ")
-
+    group_vars <- c(group_vars, "?directory")
   }
-
+  
   if (include_sector == TRUE){
-
     query <- paste(query, "?sector", sep = " ")
-
+    group_vars <- c(group_vars, "?sector")
   }
   
   if (include_advocate_general == TRUE){
-    
     query <- paste(query, "?ag", sep = " ")
-    
+    group_vars <- c(group_vars, "?ag")
   }
   
   if (include_judge_rapporteur == TRUE){
-    
     query <- paste(query, "?jr", sep = " ")
-    
+    group_vars <- c(group_vars, "?jr")
   }
   
   if (include_court_formation == TRUE){
-    
     query <- paste(query, "?cf", sep = " ")
-    
+    group_vars <- c(group_vars, "?cf")
   }
   
   if (include_court_scholarship == TRUE){
-    
     query <- paste(query, "?scholarship", sep = " ")
-    
+    group_vars <- c(group_vars, "?scholarship")
   }
   
   if (include_court_origin == TRUE){
-    
     query <- paste(query, "?courtorigin", sep = " ")
-    
+    group_vars <- c(group_vars, "?courtorigin")
   }
   
   if (include_original_language == TRUE){
-    
     query <- paste(query, "?origlang", sep = " ")
-    
+    group_vars <- c(group_vars, "?origlang")
   }
   
   if (include_proposal == TRUE){
-    
     query <- paste(query, "?proposal", sep = " ")
-    
+    group_vars <- c(group_vars, "?proposal")
   }
 
   if (resource_type == "any"){
@@ -614,10 +607,23 @@ elx_make_query <- function(resource_type = c("any","directive","regulation","dec
     'FILTER not exists{?work cdm:do_not_index "true"^^<http://www.w3.org/2001/XMLSchema#boolean>}.'
   )
   
+  # close where clause
+  query <- paste(query, "}")
+  
+  # group by (only needed when an aggregate function like group_concat is used)
+  if (include_author == TRUE){
+    query <- paste(query, "GROUP BY", paste(group_vars, collapse = " "))
+  }
+  
+  # order
   # order
   if (order == TRUE){
-    query <- paste(query, "} order by str(?date)")
-  } else {query <- paste(query, "}")} 
+    if (include_author == TRUE){
+      query <- paste(query, "order by str(?work)")
+    } else {
+      query <- paste(query, "order by str(?date)")
+    }
+  }
 
   # limit
   if (!is.null(limit) & is.integer(as.integer(limit))){

--- a/man/elx_make_query.Rd
+++ b/man/elx_make_query.Rd
@@ -123,12 +123,14 @@ Note that not all resource types are compatible with default parameter values.
 When \code{date_from} or \code{date_to} are specified, the underlying SPARQL query
 requires \code{?date} to be a well-formed \code{xsd:date}. Any document whose date
 does not resolve to a valid \code{xsd:date} would be silently excluded from
-the filtered results, without a warning or error. This has not been
-observed to occur in practice — sampling of live data (including
-pre-1970 documents, where imprecise dates would be most likely) found
-no such cases — but has been confirmed directly via a synthetic SPARQL
-test with a deliberately malformed date value, which was correctly
-excluded by the filter.
+the filtered results, without a warning or error.
+
+When \code{include_author} is \code{TRUE}, the query uses \code{GROUP_CONCAT} to combine
+multiple authors for the same document into a single pipe-separated
+(\code{|}) string in the \code{author} column, rather than returning one row per
+author. This avoids duplicate rows for documents with multiple authors,
+but means the query switches from \verb{SELECT DISTINCT} to \verb{SELECT ... GROUP BY}
+internally when \code{include_author} is used.
 }
 \examples{
 elx_make_query(resource_type = "directive", include_date = TRUE, include_force = TRUE)

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -103,3 +103,94 @@ testthat::test_that("include_date still works without date_from/date_to", {
   testthat::expect_true(grepl("OPTIONAL\\{\\?work cdm:work_date_document \\?date\\.\\}", q))
   
 })
+
+
+testthat::test_that("include_author combines multiple authors without duplicating rows", {
+  
+  testthat::skip_on_cran()
+  
+  q <- eurlex::elx_make_query(resource_type = "directive", 
+                              include_author = TRUE, 
+                              limit = 2000)
+  
+  out <- eurlex::elx_run_query(q)
+  
+  # No document should appear more than once
+  testthat::expect_true(all(table(out$work) == 1))
+  
+})
+
+testthat::test_that("include_author correctly concatenates known multi-author document", {
+  
+  testthat::skip_on_cran()
+  
+  q <- '
+  PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
+  PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+  SELECT ?work (group_concat(distinct ?author;separator="|") as ?author) WHERE {
+    VALUES ?work { <http://publications.europa.eu/resource/cellar/01d3846d-ff64-4190-a1bd-39abf9673281> }
+    OPTIONAL{
+      ?work cdm:work_created_by_agent ?authorx.
+      ?authorx skos:prefLabel ?author. 
+      FILTER(lang(?author)="en")
+    }
+  }
+  GROUP BY ?work
+  '
+  
+  out <- eurlex::elx_run_query(q)
+  
+  testthat::expect_equal(nrow(out), 1)
+  testthat::expect_true(grepl("Council of the European Union", out$author))
+  testthat::expect_true(grepl("European Parliament", out$author))
+  
+})
+
+testthat::test_that("include_author works combined with other include parameters", {
+  
+  testthat::skip_on_cran()
+  
+  q <- eurlex::elx_make_query(resource_type = "directive", 
+                              include_author = TRUE, 
+                              include_date = TRUE,
+                              include_force = TRUE,
+                              limit = 5)
+  
+  out <- eurlex::elx_run_query(q)
+  
+  testthat::expect_true(all(c("author", "date", "force") %in% names(out)))
+  testthat::expect_equal(nrow(out), 5)
+  
+})
+
+testthat::test_that("order = TRUE works correctly with include_author", {
+  
+  testthat::skip_on_cran()
+  
+  q <- eurlex::elx_make_query(resource_type = "directive", 
+                              include_author = TRUE, 
+                              order = TRUE,
+                              limit = 5)
+  
+  out <- eurlex::elx_run_query(q)
+  
+  testthat::expect_equal(nrow(out), 5)
+  
+})
+
+testthat::test_that("include_author does not affect queries without it (regression)", {
+  
+  testthat::skip_on_cran()
+  
+  q <- eurlex::elx_make_query(resource_type = "directive", 
+                              include_date = TRUE, 
+                              include_force = TRUE, 
+                              limit = 5)
+  
+  testthat::expect_true(grepl("select distinct", q))
+  testthat::expect_false(grepl("GROUP BY", q))
+  
+  out <- eurlex::elx_run_query(q)
+  testthat::expect_equal(nrow(out), 5)
+  
+})


### PR DESCRIPTION
## Context

Starting with `include_author` as suggested, to surface any edge cases 
before considering broadening this to other multi-valued fields (per 
issue #26, point 5).

## The problem

Confirmed the duplication issue is real: e.g. Directive 2005/75 
(`01d3846d-ff64-4190-a1bd-39abf9673281`) returns as two separate rows 
with `include_author = TRUE` — one for the Council, one for the 
Parliament — because it has two authors.

## The fix

When `include_author = TRUE`, the query now uses `GROUP_CONCAT` to 
combine multiple authors into a single pipe-separated string, and 
switches from `SELECT DISTINCT` to `SELECT ... GROUP BY` internally. 
When `include_author` is not used, the query is completely unchanged 
(`SELECT DISTINCT`, no `GROUP BY`).

## Edge case found and fixed

`order = TRUE` combined with `include_author = TRUE` initially broke 
with a 400 Bad Request. Reason: the original `order by str(?date)` references 
`?date`, which isn't in the `GROUP BY` clause unless `include_date` is 
also set. Fixed by ordering on `?work` instead when `include_author` 
is active (an unambiguous key that's always in the `GROUP BY` list), 
while leaving the original `?date`-based ordering untouched for all 
other cases.

## Testing

Five new tests covering: no duplicate rows, correct concatenation on 
the known multi-author case, compatibility with other `include_*` 
parameters, the `order = TRUE` edge case, and a regression check that 
the query stays as `SELECT DISTINCT` (no `GROUP BY`) when 
`include_author` isn't used.

All 37 tests pass (`devtools::test()`). `devtools::check(cran = TRUE)`: 
0 errors, 0 warnings, 1 unrelated local NOTE (libxml version mismatch).

## On broader scope

Happy to look into extending this pattern to other multi-valued fields 
(`include_eurovoc`, `include_citations`, `include_lbs`, etc.) once 
you've had a chance to look at this. I wanted to keep this PR focused 
on `author` first as discussed.